### PR TITLE
type: make options properties optional

### DIFF
--- a/src/pcm-player.d.ts
+++ b/src/pcm-player.d.ts
@@ -13,11 +13,11 @@ declare module 'pcm-player' {
     'Float32': Float32Array
   }
   interface option {
-    inputCodec: keyof inputCodecs
-    channels: number
-    sampleRate: number
-    flushTime: number
-    fftSize: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768
+    inputCodec?: keyof inputCodecs
+    channels?: number
+    sampleRate?: number
+    flushTime?: number
+    fftSize?: 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768
     onstatechange?: (node: AudioContext, event: Event, type: AudioContextState) => void
     onended?: (node: AudioBufferSourceNode, event: Event) => void
   }


### PR DESCRIPTION
Since JavaScript code already provides default values for the options, we should either make the types optional in the TypeScript definition or remove the default values from the JavaScript code and keep the types required.