### PR TITLE
fix: flushTime 为0不触发定时器，暴露flush方法

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  (global = global || self, global.PCMPlayer = factory());
-}(this, (function () { 'use strict';
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.PCMPlayer = factory());
+})(this, (function () { 'use strict';
 
   class PCMPlayer {
     constructor(option) {
@@ -20,7 +20,7 @@
 
       this.option = Object.assign({}, defaultOption, option); // 实例最终配置参数
       this.samples = new Float32Array(); // 样本存放区域
-      this.interval = setInterval(this.flush.bind(this), this.option.flushTime);
+      this.interval = this.option.flushTime ? setInterval(this.flush.bind(this), this.option.flushTime) : undefined;
       this.convertValue = this.getConvertValue();
       this.typedArray = this.getTypedArray();
       this.initAudioContext();
@@ -196,4 +196,4 @@
 
   return PCMPlayer;
 
-})));
+}));

--- a/src/pcm-player.d.ts
+++ b/src/pcm-player.d.ts
@@ -45,7 +45,7 @@ declare module 'pcm-player' {
 
     private getFormattedValue(data: ArrayBuffer | keyof typedArrays): Float32Array
 
-    private flush(): void
+    flush(): void
 
     feed(data: ArrayBuffer | keyof typedArrays): void
 

--- a/src/pcm-player.js
+++ b/src/pcm-player.js
@@ -14,7 +14,7 @@ class PCMPlayer {
 
     this.option = Object.assign({}, defaultOption, option) // 实例最终配置参数
     this.samples = new Float32Array() // 样本存放区域
-    this.interval = setInterval(this.flush.bind(this), this.option.flushTime)
+    this.interval = this.option.flushTime ? setInterval(this.flush.bind(this), this.option.flushTime) : undefined
     this.convertValue = this.getConvertValue()
     this.typedArray = this.getTypedArray()
     this.initAudioContext()


### PR DESCRIPTION
支持 flushTime 为0不触发定时器，可手动调用flush触发，主要方便用户通过队列的方式监听onended是否全部播放完成

```
// 入参部分
onended() {
 const isEnded = isEndedQueue.shift()
 if (isEnded) {
   console.log('全部放完了')
 }
}
// ws接收部分
ws.onmessage = (event) => {
 const isEnded = event.isEnded
 audioIsEndedQueue.push(isEnded)
 // 添加
 player.feed(event.arrayBuffer)
 // 手动触发
 player.flush()
 isEnded && ws.close()
}

```